### PR TITLE
fix: add missing OG type

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ const Home = (postList: { posts: [PostPreview] }) => {
         <meta name="description" content="my site" />
         <link rel="icon" href="favicon.ico" />
         <link rel="shortcut icon" href="favicon.ico" />
+        <meta property="og:type" content="website" />
         <meta property="og:title" content="wrongbyte.github.io" />
         <meta property="og:description" content="my random tech stuff" />
         <meta

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -20,6 +20,7 @@ const Post = (props: PostModel) => {
         <meta name="description" content="my site" />
         <link rel="icon" href="favicon.ico" />
         <link rel="shortcut icon" href="favicon.ico" />
+        <meta property="og:type" content="website" />
         <meta property="og:title" content={props.title} />
         <meta property="og:description" content={props.description} />
         <meta


### PR DESCRIPTION
An attempt to fix https://github.com/wrongbyte/wrongbyte.github.io/issues/4
Looking at the [ogp](https://ogp.me/), it seems to be the only meta tag missing on your website (home & post pages).

I think the only way to properly test it is to deploy and share an article on Twitter.